### PR TITLE
Replace pmap gem with pure-Ruby thread pool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # 2.6, or the no-install-needed story on macOS breaks.
 ruby '>= 2.6.0'
 
-# git_report's only runtime dependency. Everything else it needs is in the
-# Ruby standard library, so the tool runs on the stock macOS system Ruby
-# without the user installing Ruby or any other gems.
-gem 'pmap'
+# git_report has no runtime dependencies: everything it needs is in the Ruby
+# standard library, so the tool runs on the stock macOS system Ruby without the
+# user installing Ruby or any gems. Parallelism uses plain threads (see
+# lib/git/parallel.rb). Keep this Gemfile dependency-free.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
      \___/'                       (_)
 ```
 
-> A single command — `git report` — that tells you who wrote the code in any Git repository.
+R> A single command — `git report` — that tells you who wrote the code in any Git repository.
 
 [![CI](https://github.com/wteuber/git_report/actions/workflows/ci.yml/badge.svg)](https://github.com/wteuber/git_report/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -73,8 +73,8 @@ cd /path/to/any/repo
 git report             # print the contributor table
 ```
 
-The first run installs the one dependency (`pmap`) into a project-local
-`vendor/` directory; every run after that is instant.
+There is nothing to install — `git_report` has no gem dependencies and runs
+straight off the stock system Ruby.
 
 ## Understanding the Output
 
@@ -103,9 +103,9 @@ ignored, so the report reflects committed history only.
 - 📊 Per-author commit, line, and file statistics in one table
 - 🧬 Distinguishes surviving code (`LOC`) from lifetime additions/deletions (`+LOC`/`-LOC`)
 - 🔀 Merges contributors who used multiple email addresses
-- 🚀 Parallel processing (via `pmap`) for fast analysis of large repositories
+- 🚀 Parallel processing (plain Ruby threads) for fast analysis of large repositories
 - 🌐 Global `git report` command that works in any repository
-- 🧰 Zero global footprint — installs its one gem into an isolated local `vendor/`
+- 🧰 Zero dependencies — pure Ruby standard library, nothing to install
 - 💎 Runs on Ruby 2.6 through 3.4+, including the stock macOS system Ruby
 
 ## Requirements
@@ -137,28 +137,24 @@ git config --global alias.report "!sh -c \"/path/to/git_report/bin/git_report\""
 
 ### Dependencies
 
-The only runtime dependency is the [`pmap`](https://rubygems.org/gems/pmap) gem;
-everything else comes from the Ruby standard library. On first run `git_report`
-installs `pmap` into a project-local `vendor/` directory with an isolated
-`GEM_HOME`/`GEM_PATH` — no Bundler, no global install, no version conflicts. To
-install it manually instead:
-
-```bash
-gem install pmap
-```
+None. `git_report` uses only the Ruby standard library — parallelism is built on
+plain `Thread` (see [`lib/git/parallel.rb`](lib/git/parallel.rb)) — so there is
+no gem to install, no Bundler, and no version conflicts. It runs directly on
+whatever Ruby is on your `PATH`, including the stock macOS system Ruby.
 
 ## How It Works
 
 1. **Git analysis** — gathers contributor data with `git shortlog` (commits),
    `git blame -w` (surviving lines and files), and `git log --numstat` (lifetime
    additions/deletions).
-2. **Parallel processing** — uses `pmap` to fan blame and log work out across
-   files and authors, keeping large repositories fast.
+2. **Parallel processing** — uses plain Ruby threads to fan blame and log work
+   out across files and authors, keeping large repositories fast. The git
+   subprocesses are I/O-bound and release the GVL, so threads give real
+   concurrency without any gem.
 3. **Author deduplication** — merges authors who committed under the same name
    with different email addresses into a single row.
-4. **Isolated dependencies** — installs its one gem into a project-local
-   `vendor/` directory under an isolated `GEM_HOME`/`GEM_PATH`, so it never
-   clashes with the gems of whatever Ruby is on your `PATH`.
+4. **No dependencies** — relies only on the Ruby standard library, so it runs on
+   whatever Ruby is on your `PATH` with nothing to install.
 
 ## Compatibility
 
@@ -167,7 +163,7 @@ gem install pmap
 - ✅ Ruby **2.6 (support floor) through 3.4+**, both verified in CI
 - ✅ Runs on the stock macOS system Ruby — end users need no Ruby install
 - ✅ Works with system Ruby or version managers (rbenv, rvm, chruby)
-- ✅ Installs its gem locally to avoid permission and version conflicts
+- ✅ No gems to install, so no permission or version conflicts
 
 The Ruby version floor is enforced by RuboCop (`TargetRubyVersion: 2.6`) and a CI
 matrix that runs against both 2.6 and a recent Ruby. The `.ruby-version` file
@@ -176,21 +172,12 @@ narrow the supported range.
 
 ## Troubleshooting
 
-**Permission errors installing gems** — none expected: `git_report` installs into
-a local `vendor/` directory rather than a system location. If you still hit
-trouble, ensure the project directory is writable.
+**Permission errors installing gems** — not applicable: `git_report` installs no
+gems. It runs entirely on the Ruby standard library.
 
 **Ruby version issues** — the `.ruby-version` file selects Ruby 3.4.9 for local
 development, but the tool supports any Ruby from 2.6 up and does not use Bundler
 at runtime, so Bundler version conflicts cannot affect it.
-
-**Missing or broken dependencies** — clear the local gem cache and let the tool
-reinstall on the next run:
-
-```bash
-cd /path/to/git_report
-rm -rf vendor
-```
 
 **"Not a git repository"** — run `git report` from inside a Git working tree;
 the tool reports on the repository in the current directory.
@@ -208,14 +195,15 @@ git_report/
 ├── lib/
 │   ├── git_report.rb # Entry point (loads the Git:: classes)
 │   └── git/
-│       ├── author.rb # Author statistics class
-│       └── report.rb # Report generation class
+│       ├── author.rb   # Author statistics class
+│       ├── parallel.rb # Thread-based parallel map/each helpers
+│       └── report.rb   # Report generation class
 ├── test/
 │   └── smoke_test.rb # End-to-end smoke test
 ├── .github/workflows/
 │   └── ci.yml        # CI: smoke test (Ruby 2.6 + 3.4) and RuboCop
 ├── .rubocop.yml      # Lint config; enforces the Ruby 2.6 syntax floor
-├── Gemfile           # Ruby dependencies (just pmap)
+├── Gemfile           # Declares the Ruby floor (no gem dependencies)
 ├── .ruby-version     # Ruby for local development (does not narrow support)
 └── README.md         # This file
 ```

--- a/bin/git_report
+++ b/bin/git_report
@@ -2,39 +2,11 @@
 # encoding: utf-8
 
 # git_report runs on whatever Ruby is on PATH -- including the stock macOS
-# system Ruby -- so users don't have to install Ruby. Its single runtime
-# dependency (pmap) is installed into a project-local, isolated vendor
-# directory rather than relying on Bundler or the user's global gems.
+# system Ruby -- so users don't have to install Ruby. It has no gem
+# dependencies: everything it needs comes from the Ruby standard library, so
+# there is nothing to install and no first-run vendoring step.
 
-require 'fileutils'
-
-script_dir  = File.expand_path(File.dirname(__FILE__))
-project_dir = File.expand_path('..', script_dir)
-
-# Isolate the gem environment from the user's shell. Without this, a GEM_HOME /
-# GEM_PATH inherited from a chruby/rbenv Ruby (e.g. 3.x) leaks into the system
-# Ruby and blows up with "Symbol not found" native-extension errors when it
-# tries to load gems built for a different Ruby ABI.
-gem_home = File.join(project_dir, 'vendor', 'gems', "ruby-#{RUBY_VERSION}")
-FileUtils.mkdir_p(gem_home)
-ENV['GEM_HOME'] = gem_home
-ENV['GEM_PATH'] = gem_home
-ENV.delete('RUBYOPT')
-ENV.delete('BUNDLE_GEMFILE')
-
-# Install the dependency on first run.
-pmap_installed = Dir.glob(File.join(gem_home, 'gems', 'pmap-*')).any?
-unless pmap_installed
-  puts 'Installing required gems...'
-  unless system('gem', 'install', 'pmap', '--no-document', '--install-dir', gem_home)
-    abort 'Failed to install pmap. Please install it manually: gem install pmap'
-  end
-end
-
-# Pick up the isolated gem path in this already-running process, then make the
-# gem's lib directory loadable.
-Gem.clear_paths
-Dir[File.join(gem_home, 'gems', '*', 'lib')].each { |path| $LOAD_PATH.unshift(path) }
+script_dir = File.expand_path(File.dirname(__FILE__))
 
 require File.join(script_dir, '../lib/git_report.rb')
 

--- a/lib/git/author.rb
+++ b/lib/git/author.rb
@@ -37,15 +37,18 @@ module Git
     end
 
     def retrieve_loc_stats
-      emails.pmap do |email|
+      # Run one git log per email in parallel, returning [added, deleted] per
+      # email. The instance-variable accumulation happens afterwards on this
+      # single thread, so the parallel blocks never race on @loc_added/@loc_deleted.
+      Git::Parallel.pmap(emails) do |email|
         # Escape email to prevent command injection
         escaped_email = Shellwords.escape(email)
         numstat = `git log --author=#{escaped_email} \
           --pretty=tformat: --numstat --no-merges`
-        
+
         # Skip if no commits found for this email
         next if numstat.empty?
-        
+
         loc = numstat.split(/\n/).map do |numstat_line|
           parts = numstat_line.scan(/\A(.*)\t(.*)\t/)[0]
           parts ? parts.map(&:to_i) : nil
@@ -53,10 +56,11 @@ module Git
 
         # Skip if no valid data
         next if loc.empty?
-        
-        added, deleted = loc.transpose.map do |add_del_loc|
-          add_del_loc.inject(&:+)
-        end
+
+        loc.transpose.map { |add_del_loc| add_del_loc.inject(&:+) }
+      end.each do |added_deleted|
+        next unless added_deleted
+        added, deleted = added_deleted
         @loc_added += added if added
         @loc_deleted += deleted if deleted
       end

--- a/lib/git/parallel.rb
+++ b/lib/git/parallel.rb
@@ -1,0 +1,67 @@
+module Git
+  # Minimal parallel helpers built on the Ruby standard library, replacing the
+  # former `pmap` gem. The work these drive is I/O-bound -- every block shells
+  # out to git -- so threads give real concurrency even under MRI's GVL: a
+  # subprocess spawned by backticks runs outside the lock while other threads
+  # proceed. Keeping this in-tree is what lets git_report run on stock Ruby
+  # with no gems to install.
+  module Parallel
+    # Upper bound on worker threads, and therefore on how many git subprocesses
+    # run at once. This cap is the whole point: a repository with thousands of
+    # authors must NOT spawn a thread (and a `git log`) per author -- that would
+    # swamp the machine. 64 matches the historical default of the pmap gem this
+    # replaced, so throughput on large repositories is unchanged.
+    MAX_THREADS = 64
+
+    module_function
+
+    # Like Enumerable#map, but runs the block for each element across a bounded
+    # pool of threads and returns the results in the original order.
+    def pmap(enum, &block)
+      results = []
+      mutex = Mutex.new
+      process(enum) do |item, index|
+        value = block.call(item)
+        mutex.synchronize { results[index] = value }
+      end
+      results
+    end
+
+    # Like Enumerable#each, but runs the block for each element across a bounded
+    # pool of threads. Returns the original enumerable once all work is done.
+    def peach(enum, &block)
+      process(enum) { |item, _index| block.call(item) }
+      enum
+    end
+
+    # Drains every [item, index] pair through at most MAX_THREADS workers. All
+    # jobs are enqueued up front, so each worker simply pops until the queue is
+    # empty and then exits -- no poison pills needed. Joining via Thread#value
+    # propagates the first exception raised in any worker to the caller.
+    def process(enum)
+      items = enum.to_a
+      queue = Queue.new
+      items.each_with_index { |item, index| queue << [item, index] }
+
+      worker_count = [items.size, MAX_THREADS].min
+      workers = Array.new(worker_count) do
+        Thread.new do
+          # We re-raise from Thread#value below, so silence Ruby's automatic
+          # "terminated with exception" dump to stderr -- it would otherwise
+          # print the same error twice.
+          Thread.current.report_on_exception = false
+          loop do
+            begin
+              item, index = queue.pop(true)
+            rescue ThreadError
+              break # queue drained
+            end
+            yield item, index
+          end
+        end
+      end
+      workers.each(&:value)
+    end
+    private_class_method :process
+  end
+end

--- a/lib/git/report.rb
+++ b/lib/git/report.rb
@@ -45,7 +45,7 @@ module Git
         add shortlog_line
       end
 
-      authors.peach(&:retrieve_loc_stats)
+      Git::Parallel.peach(authors, &:retrieve_loc_stats)
     end
 
     def parse_blame
@@ -58,7 +58,7 @@ module Git
       names_loc_count = Hash.new(0)
       names_files     = {}
 
-      file_lists.peach do |files|
+      Git::Parallel.peach(file_lists) do |files|
         files.each do |file|
           escaped_file = Shellwords.escape(file)
           blame = `git blame -w #{escaped_file} 2> /dev/null`

--- a/lib/git_report.rb
+++ b/lib/git_report.rb
@@ -1,4 +1,3 @@
-require 'pmap'
 require 'set'
 
 # Git module - contains classes for analyzing git repository statistics

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# End-to-end smoke test. It drives the real bin/git_report launcher -- including
-# its gem-vendoring step -- against a throwaway git repository, so it exercises
-# exactly what an end user runs. minitest ships with Ruby (a default gem), so
+# End-to-end smoke test. It drives the real bin/git_report launcher against a
+# throwaway git repository, so it exercises exactly what an end user runs --
+# including that the tool needs no gems installed. minitest ships with Ruby (a
+# default gem), so
 # this adds no dependency and runs on the 2.6 support floor as well as modern
 # Rubies.
 require 'minitest/autorun'


### PR DESCRIPTION
## Summary

`git_report`'s only dependency was the [`pmap`](https://rubygems.org/gems/pmap) gem, used for parallel `map`/`each` over authors, emails, and file slices. This replaces it with a small in-tree helper, `Git::Parallel`, built entirely on the Ruby standard library. The tool now runs on stock Ruby (including the macOS system Ruby) with **nothing to install**.

## What changed

- **`lib/git/parallel.rb` (new)** — a bounded worker pool providing `pmap`/`peach`. `MAX_THREADS = 64` matches pmap 1.1.1's historical default, so throughput on large repos is unchanged. The cap is essential: a naive one-thread-per-element version would spawn thousands of concurrent `git` subprocesses on a large repo (a fork bomb). Workers drain a pre-filled queue and exit when empty; `Thread#value` propagates the first worker exception to the caller.
- **`lib/git/author.rb`** — `+LOC`/`-LOC` now accumulate on the main thread after the parallel blocks return, fixing a latent cross-thread `+=` race that existed under the old `pmap` usage too.
- **`bin/git_report`** — removed the gem-vendoring / first-run `gem install` machinery that existed solely to install pmap. The launcher is now a few lines.
- **`Gemfile`** — removed `gem 'pmap'`; the project is now dependency-free.
- **README + smoke-test comments** — updated to reflect zero dependencies.

## Verification

- ✅ Smoke test passes on Ruby 3.4 (`2 runs, 12 assertions, 0 failures`)
- ✅ Runs on stock macOS system Ruby 2.6 with no gems installed
- ✅ RuboCop clean (2.6 target, `7 files, no offenses`)
- ✅ 5000-item stress test confirms peak concurrency never exceeds the 64-thread cap, result order is preserved, and exceptions propagate cleanly
- ✅ Output matches the previous pmap-based version