### PR TITLE
Rename gem to git-author-report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2026-06-23
 
 ### Added
-- First release as the `git-report` gem, installable via `gem install git-report`.
-- Gem packaging: `git-report.gemspec`, `VERSION`, `lib/version.rb`, and a
+- First release as the `git-author-report` gem, installable via
+  `gem install git-author-report`. The executable is `git-report`, so the tool
+  runs as `git report`.
+- Gem packaging: `git-author-report.gemspec`, `VERSION`, `lib/version.rb`, and a
   `Rakefile` running the test suite and RuboCop.
 - `gem install` sets up the `git report` alias (via `bin/git_add_alias_report`),
   and `gem uninstall` removes it (via a `rubygems_plugin.rb` `pre_uninstall` hook
@@ -19,11 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `git-report --version` / `-v` prints the version.
 
 ### Changed
-- **BREAKING**: Renamed the project from `git_report` to `git-report` (gem,
-  executable, repository, and documentation). The Ruby source file
-  `lib/git_report.rb` keeps its underscore per Ruby file-naming convention.
+- **BREAKING**: Renamed the project from `git_report` to `git-author-report`
+  (gem, repository, and documentation). The executable stays `git-report` so the
+  tool is invoked as `git report`. The Ruby source file `lib/git_report.rb`
+  keeps its underscore per Ruby file-naming convention.
 - `bin/install` / `bin/uninstall` renamed to `bin/git_add_alias_report` /
   `bin/git_remove_alias_report`.
 
-[Unreleased]: https://github.com/wteuber/git-report/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/wteuber/git-report/releases/tag/v1.0.0
+[Unreleased]: https://github.com/wteuber/git-author-report/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/wteuber/git-author-report/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git-report
+# git report
 
 ```
                _                                       _
@@ -13,12 +13,12 @@
 
 R> A single command — `git report` — that tells you who wrote the code in any Git repository.
 
-[![CI](https://github.com/wteuber/git-report/actions/workflows/ci.yml/badge.svg)](https://github.com/wteuber/git-report/actions/workflows/ci.yml)
-[![Gem Version](https://img.shields.io/gem/v/git-report.svg)](https://rubygems.org/gems/git-report)
+[![CI](https://github.com/wteuber/git-author-report/actions/workflows/ci.yml/badge.svg)](https://github.com/wteuber/git-author-report/actions/workflows/ci.yml)
+[![Gem Version](https://img.shields.io/gem/v/git-author-report.svg)](https://rubygems.org/gems/git-author-report)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Ruby](https://img.shields.io/badge/Ruby-2.6%20–%204.0%2B-CC342D.svg)](.ruby-version)
 
-`git-report` analyzes a repository and prints a per-author breakdown of how much
+`git-author-report` analyzes a repository and prints a per-author breakdown of how much
 code each contributor wrote — surviving lines, lifetime additions and deletions,
 commit counts, and files touched — as a clean ASCII table. It runs on whatever
 Ruby is already on your machine (including the stock macOS system Ruby), needs no
@@ -36,7 +36,7 @@ gems.
 
 ## Table of Contents
 
-- [Why git-report?](#why-git-report)
+- [Why git-author-report?](#why-git-author-report)
 - [Quick Start](#quick-start)
 - [Understanding the Output](#understanding-the-output)
 - [Features](#features)
@@ -49,10 +49,10 @@ gems.
 - [Uninstallation](#uninstallation)
 - [License](#license)
 
-## Why git-report?
+## Why git-author-report?
 
 `git shortlog` tells you who committed and how often, but commit counts are a
-poor proxy for contribution. `git-report` answers the questions that actually
+poor proxy for contribution. `git-author-report` answers the questions that actually
 matter:
 
 - **Who owns the code that exists today?** The `LOC` column counts the lines each
@@ -66,13 +66,13 @@ matter:
 ## Quick Start
 
 ```bash
-gem install git-report   # also registers a global `git report` alias
+gem install git-author-report   # also registers a global `git report` alias
 
 cd /path/to/any/repo
-git report               # print the contributor table
+git report                      # print the contributor table
 ```
 
-There is nothing else to install — `git-report` has no runtime gem dependencies
+There is nothing else to install — `git-author-report` has no runtime gem dependencies
 and runs straight off the stock system Ruby.
 
 ## Understanding the Output
@@ -118,7 +118,7 @@ ignored, so the report reflects committed history only.
 ### Install as a gem (recommended)
 
 ```bash
-gem install git-report
+gem install git-author-report
 ```
 
 Installing the gem also registers a global Git alias so you can run `git report`
@@ -129,8 +129,8 @@ directory is on your `PATH`.)
 ### From a clone
 
 ```bash
-git clone https://github.com/wteuber/git-report.git
-cd git-report
+git clone https://github.com/wteuber/git-author-report.git
+cd git-author-report
 ./bin/git_add_alias_report
 ```
 
@@ -141,12 +141,12 @@ This registers the same global `git report` alias without installing the gem.
 If you'd rather wire up the alias yourself:
 
 ```bash
-git config --global alias.report "!exec \"/path/to/git-report/bin/git-report\""
+git config --global alias.report "!exec \"/path/to/git-author-report/bin/git-report\""
 ```
 
 ### Dependencies
 
-None at runtime. `git-report` uses only the Ruby standard library — parallelism
+None at runtime. `git-author-report` uses only the Ruby standard library — parallelism
 is built on plain `Thread` (see [`lib/git/parallel.rb`](lib/git/parallel.rb)) —
 so there is no gem to install, no Bundler, and no version conflicts. It runs
 directly on whatever Ruby is on your `PATH`, including the stock macOS system
@@ -168,7 +168,7 @@ Ruby.
 
 ## Compatibility
 
-`git-report` is designed to run anywhere Git and Ruby already exist:
+`git-author-report` is designed to run anywhere Git and Ruby already exist:
 
 - ✅ Ruby **2.6 (support floor) through 4.0+**, all verified in CI
 - ✅ Runs on the stock macOS system Ruby — end users need no Ruby install
@@ -182,10 +182,10 @@ development — it does **not** narrow the supported range.
 
 ## Troubleshooting
 
-**Permission errors installing gems** — `git-report` has no runtime
-dependencies, so the only gem involved is `git-report` itself. If `gem install`
+**Permission errors installing gems** — `git-author-report` has no runtime
+dependencies, so the only gem involved is `git-author-report` itself. If `gem install`
 needs elevated permissions, install into your user gem dir
-(`gem install --user-install git-report`) or use a version manager.
+(`gem install --user-install git-author-report`) or use a version manager.
 
 **Ruby version issues** — the `.ruby-version` file selects Ruby 4.0.4 for local
 development, but the tool supports any Ruby from 2.6 up and does not use Bundler
@@ -199,7 +199,7 @@ the tool reports on the repository in the current directory.
 ### Project Structure
 
 ```
-git-report/
+git-author-report/
 ├── bin/
 │   ├── git-report              # Main executable
 │   ├── git_add_alias_report    # Registers the `git report` alias
@@ -216,7 +216,7 @@ git-report/
 │       ├── parallel.rb         # Thread-based parallel map/each helpers
 │       └── report.rb           # Report generation class
 ├── test/                       # minitest suite (smoke + unit tests)
-├── git-report.gemspec          # Gem specification
+├── git-author-report.gemspec   # Gem specification
 ├── VERSION                     # Single source of truth for the version
 ├── Rakefile                    # `rake` runs tests + RuboCop
 ├── .github/workflows/
@@ -257,13 +257,13 @@ Contributions are welcome!
 If you installed the gem:
 
 ```bash
-gem uninstall git-report   # also removes the global `git report` alias
+gem uninstall git-author-report   # also removes the global `git report` alias
 ```
 
 If you installed from a clone:
 
 ```bash
-cd /path/to/git-report
+cd /path/to/git-author-report
 ./bin/git_remove_alias_report
 ```
 
@@ -279,7 +279,7 @@ Released under the [MIT License](LICENSE).
 
 ## Links
 
-- **Repository**: https://github.com/wteuber/git-report
-- **Issues**: https://github.com/wteuber/git-report/issues
-- **Pull Requests**: https://github.com/wteuber/git-report/pulls
+- **Repository**: https://github.com/wteuber/git-author-report
+- **Issues**: https://github.com/wteuber/git-author-report/issues
+- **Pull Requests**: https://github.com/wteuber/git-author-report/pulls
 </content>

--- a/git-author-report.gemspec
+++ b/git-author-report.gemspec
@@ -3,21 +3,21 @@
 require_relative 'lib/version'
 
 Gem::Specification.new do |s|
-  s.name                  = 'git-report'
+  s.name                  = 'git-author-report'
   s.required_ruby_version = '>= 2.6'
   s.version               = Git::Report::VERSION
   s.licenses              = ['MIT']
   s.summary               = 'Per-author contribution report for any git repository'
-  s.description           = 'git-report is a command line tool that prints a per-author ' \
-                            'breakdown of code contribution (surviving LOC, lifetime ' \
-                            '+/-LOC, commits, files) as an ASCII table.'
+  s.description           = 'git-author-report is a command line tool, run as `git report`, ' \
+                            'that prints a per-author breakdown of code contribution ' \
+                            '(surviving LOC, lifetime +/-LOC, commits, files) as an ASCII table.'
   s.authors               = ['Wolfgang Teuber']
   s.email                 = 'knugie@gmx.net'
   s.files                 = Dir['{lib/**/*.rb,bin/*}'] + Dir['ext/git_report/Makefile'] + ['VERSION']
   s.require_paths         = ['lib']
   s.executables           = ['git-report']
   s.extensions            = Dir['ext/git_report/extconf.rb']
-  s.homepage              = 'https://github.com/wteuber/git-report'
-  s.metadata              = { 'source_code_uri' => 'https://github.com/wteuber/git-report',
+  s.homepage              = 'https://github.com/wteuber/git-author-report'
+  s.metadata              = { 'source_code_uri' => 'https://github.com/wteuber/git-author-report',
                               'rubygems_mfa_required' => 'true' }
 end


### PR DESCRIPTION
RubyGems rejected publishing **git-report** — its similarity check normalizes names by stripping separators, so `git-report` → `gitreport`, which collides with the existing [`gitreport`](https://rubygems.org/gems/gitreport) gem.

Renames the gem and repository to **git-author-report**. The executable stays `git-report`, so the tool is still invoked as `git report` — no UX change for users.

## Changes
- `git-report.gemspec` → `git-author-report.gemspec`; updated `name`, `homepage`, `source_code_uri`.
- README/CHANGELOG: gem name, `gem install`/`gem uninstall` commands, badges, and repo URLs updated. Executable (`git-report`) and command (`git report`) references left unchanged.

## Verified locally (Ruby 4.0.4)
- `gem build git-author-report.gemspec` → builds `git-author-report-1.0.0.gem`.
- `ruby test/coverage.rb` → 14 runs, 0 failures, 100% coverage. RuboCop clean.

Publishing **v1.0.0** to RubyGems + git tag + GitHub release follows after merge.